### PR TITLE
fix(renovate): batch Compose updates together

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
   "ignoreUnstable": false,
   "packageRules": [
     {
+      "matchPackagePatterns": [
+        "^androidx.compose"
+      ],
+      "group": "compose",
       "automerge": true,
       "automergeType": "pr",
       "platformAutomerge": true


### PR DESCRIPTION
This will prevent having to deal with a PR storm on every AndroidX release day

(Also fixes the config error from #1)