### PR TITLE
Use newer Compose compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,17 +5,7 @@ build/
 /local.properties
 
 # IntelliJ .idea folder
-.idea/workspace.xml
-.idea/misc.xml
-.idea/libraries
-.idea/caches
-.idea/navEditor.xml
-.idea/tasks.xml
-.idea/modules.xml
-.idea/compiler.xml
-.idea/jarRepositories.xml
-.idea/deploymentTargetDropDown.xml
-.idea/androidTestResultsUserPreferences.xml
+.idea/
 gradle.xml
 *.iml
 

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.8.21" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-
 repositories {
     google()
     mavenCentral()

--- a/testapp/build.gradle.kts
+++ b/testapp/build.gradle.kts
@@ -1,15 +1,17 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("com.android.library") version "8.4.2"
-    id("org.jetbrains.kotlin.android")  version "2.0.0"
+    kotlin("android") version "2.0.0"
+    kotlin("plugin.compose") version "2.0.0"
 }
 
 android {
     namespace = "dev.chrisbanes.compose.bom.testapp"
-    compileSdk = 32
+    compileSdk = 34
 
     defaultConfig {
         minSdk = 27
-        targetSdk = 32
     }
 
     compileOptions {
@@ -17,16 +19,14 @@ android {
         targetCompatibility = JavaVersion.VERSION_1_8
     }
 
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
-
     buildFeatures {
         compose = true
     }
+}
 
-    composeOptions {
-        kotlinCompilerExtensionVersion = "1.5.14"
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_1_8)
     }
 }
 


### PR DESCRIPTION
Switches over to the new version that ships alongside Kotlin.

Also some other minor cleanup:
- Switch to newer Kotlin compiler options config API
- Remove some local IntelliJ IDEA config files
- Remove `targetSdk` from `testApp` since it's configured as a library and it doesn't make sense there
- Bump up the `compileSdk` in `testApp`, although there's no real difference here